### PR TITLE
Fix test failure on darwin

### DIFF
--- a/tests/test_rfc3339_validator.py
+++ b/tests/test_rfc3339_validator.py
@@ -40,7 +40,7 @@ RFC3339_REGEX_UNICODE = re.compile(RFC3339_REGEX, re.X)
 
 @pytest.mark.skipif(six.PY2, reason="Requires python3 or higher, because strftime on python 2 only supports dates "
                                     "newer than 1900")
-@given(datetime_str=st.datetimes().map(lambda d: d.strftime("%4Y-%m-%dT%H:%M:%SZ")))
+@given(datetime_str=st.datetimes().filter(lambda d: d.year > 1000).map(lambda d: d.strftime("%Y-%m-%dT%H:%M:%SZ")))
 def test_valid_dates(datetime_str):
     assert validate_rfc3339(datetime_str)
 


### PR DESCRIPTION
On darwin, the tests fail: https://nix-cache.s3.amazonaws.com/log/z095m9zik39gh3miqp3w03z8dxbynnqx-python3.9-rfc3339-validator-0.1.3.drv

The issue looks like this: https://bugs.python.org/issue13305

> > About Elena Oat's patch issue13305.diff: I'm not sure that
> > strftime("%4Y") works on all platforms

> It doesn't, that's what the patch is trying to document.
> AFAICT it works on my Linux (but not on yours), it gives '4Y' on Mac, and raises an error on Windows.  This should depend on the libc used by system, so the same OS can give different results depending on which libc it uses, and the only sure thing is > that %4Y is not a portable solution.
> FWIW the patch LGTM (except a couple minor nits -- zero-pad should be hyphenated and there should be a double space after the dot), but I'm not sure if it's better mentioning platforms at all or just being vague and say that it works on some platforms but not others and leave up to the user figuring out where.

I worked around this by using %Y and restricting the tests to dates above 1000.